### PR TITLE
fix: use extension-module for pyo3 (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Learning Formal Mathematics From Intrinsic Motivation
+# Goal-Conditionally Learning Formal Mathematics From Intrinsic Motivation
 
-This is the implementation of the following paper:
+This repository implements a first approach to goal-conditioned self-improvement. We extend the [minimo repository](https://github.com/gpoesia/minimo) with goal-conditioning and show that our approach to goal-conditioning leads to meaningfully faster convergence to solutions to human-input problems. We will soon publish an accompanying blog post on [our blog](https://pdoom.org/blog.html).
 
+The upstream `minimo` repository is based on the following paper:
 ```bibtex
 @article{poesia2024learning,
   title={Learning Formal Mathematics From Intrinsic Motivation},
@@ -11,7 +12,9 @@ This is the implementation of the following paper:
 }
 ```
 
-You can find it on [arXiv](https://arxiv.org/abs/2407.00695). This repository builds on the [original Peano code base](https://github.com/gpoesia/peano), though it stands alone.
+The rest of the `README` is from the upstream repository.
+
+---
 
 ### Compiling the environment
 

--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -25,4 +25,4 @@ smallvec = "1.10.0"
 
 [dependencies.pyo3]
 version = "0.20.2"
-features = ["abi3-py38"]
+features = ["extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "gc-minimo"
+version = "0.1.0"
+description = "Goal-Conditionally Learning Formal Mathematics from Intrinsic Motivation"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []


### PR DESCRIPTION
Fixes issues with using python version different from `python3.8` on `cargo build --bin peano --release `