### PR TITLE
fix: use extension-module for pyo3

### DIFF
--- a/environment/Cargo.toml
+++ b/environment/Cargo.toml
@@ -25,4 +25,4 @@ smallvec = "1.10.0"
 
 [dependencies.pyo3]
 version = "0.20.2"
-features = ["abi3-py38"]
+features = ["extension-module"]


### PR DESCRIPTION
Just the first commit (removing the additional commits from https://github.com/gpoesia/minimo/pull/3)