### PR TITLE
fixed rediscovering trivial conjectures

### DIFF
--- a/learning/bootstrap.py
+++ b/learning/bootstrap.py
@@ -115,13 +115,14 @@ async def teacher_loop(cfg: DictConfig):
                 proposal = sample_conjecture(AgentLM(agent, 'Conj:(hard) '), context)
 
                 if proposal and proposal not in conjectures + proven_conjectures:
-                    conjectures.append(proposal)
-                    progress_bar.update(1)
+                    # Contract conjectures to make them Peano-parseable.
+                    contracted_proposal = d.contract(proposal)
+                    if contracted_proposal not in conjectures + proven_conjectures:
+                        conjectures.append(contracted_proposal)
+                        progress_bar.update(1)
 
             progress_bar.close()
 
-            # Contract conjectures to make them Peano-parseable.
-            conjectures = [d.contract(c) for c in conjectures]
 
             print(now(), 'done, have', len(conjectures), 'conjectures')
             print(conjectures)


### PR DESCRIPTION
The current implementation allows the model to rediscover already proven conjectures because we compare the raw `proposal` against the `proven_conjectures` variable, which contains conjectures that have been contracted. 