### PR TITLE
fix: use format_exception instead of format_exc

### DIFF
--- a/learning/worker.py
+++ b/learning/worker.py
@@ -85,7 +85,7 @@ def try_prove(agent_dump: bytes, theory: BackgroundTheory, statement: str) -> St
             logprob,
         )
     except BaseException as e:
-        tb = traceback.format_exc(e)
+        tb = traceback.format_exception(e)
         print('Error in try_prove!')
         print(tb)
         return StudentResult(tb, False, statement, None, None, [],


### PR DESCRIPTION
We need to use [`format_exception`](https://docs.python.org/3/library/traceback.html#traceback.format_exception)instead of [`format_exc`](https://docs.python.org/3/library/traceback.html#traceback.format_exc) here.